### PR TITLE
Properly parse escaped string interpolation in multiline strings.

### DIFF
--- a/dev/index.ts
+++ b/dev/index.ts
@@ -36,6 +36,7 @@ rec {
   multiline_string = ''
     This is a multiline string. \${1 + 3}
     \\\${this is not interpolated}
+    ''\${this is not either}
     'some string in single quotes' \${nixpkgs}
   '';
 }

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -47,7 +47,7 @@ export const scanIndString = new ExternalTokenizer((input) => {
       break;
     } else if (next === apostrophe && afterApostrophe) {
       if (input.peek(1) === dollar) {
-        input.advance(1);
+        input.advance();
       } else {
         if (i > 1) input.acceptToken(indStrContent, -1);
         else input.acceptToken(indStrEnd, 1);

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -46,9 +46,13 @@ export const scanIndString = new ExternalTokenizer((input) => {
       if (i > 0) input.acceptToken(indStrContent);
       break;
     } else if (next === apostrophe && afterApostrophe) {
-      if (i > 1) input.acceptToken(indStrContent, -1);
-      else input.acceptToken(indStrEnd, 1);
-      break;
+      if (input.peek(1) === dollar) {
+        input.advance(1);
+      } else {
+        if (i > 1) input.acceptToken(indStrContent, -1);
+        else input.acceptToken(indStrEnd, 1);
+        break;
+      }
     } else if (next === braceL && afterDollar) {
       if (i == 1) input.acceptToken(indStrDollarBrace, 1);
       else input.acceptToken(indStrContent, -1);


### PR DESCRIPTION
If a `${}` is preceded with `''` it is not treated as a string interpolation.

Before:
![image](https://user-images.githubusercontent.com/9086315/161412461-0f34211b-d894-4beb-ae58-8804e5b68d6d.png)

After:
![image](https://user-images.githubusercontent.com/9086315/161412439-76f0fdad-f9c0-49b4-ab47-767485b8d6ac.png)
